### PR TITLE
Add secret environment variables for network testing

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -27,6 +27,14 @@ jobs:
 
       - name: Run Android Linter
         run: ./gradlew lintDebug
+        
+      - name: Set Key Export Environment Variable
+        env:
+          SPHINX_CHAT_KEY_EXPORT: ${{ secrets.SPHINX_CHAT_KEY_EXPORT }}
+          
+      - name: Set Key Export Password Environment Variable
+        env:
+          SPHINX_CHAT_EXPORT_PASS: ${{ secrets.SPHINX_CHAT_EXPORT_PASS }}
 
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest


### PR DESCRIPTION
This PR adds secret environment variables to be used in GitHub Actions for a test Sphinx Chat account in order to run network tests against an actual relay backend.