### PR TITLE
FIX: Remove ContactId wrapper class requirement

### DIFF
--- a/sphinx/application/common/wrappers/wrapper-common/src/main/java/chat/sphinx/wrapper_common/contact/ContactId.kt
+++ b/sphinx/application/common/wrappers/wrapper-common/src/main/java/chat/sphinx/wrapper_common/contact/ContactId.kt
@@ -1,9 +1,3 @@
 package chat.sphinx.wrapper_common.contact
 
-inline class ContactId(val value: Long) {
-    init {
-        require(value >= 0L) {
-            "ContactId must be greater than or equal 0"
-        }
-    }
-}
+inline class ContactId(val value: Long)


### PR DESCRIPTION
This PR fixes an issue where by Contacts coming off the wire can have a negative value for their PrimaryKey. It removes the requirement check for positive `Long`s on the `ContactId` wrapper class.

Resolves #105 