### PR TITLE
Fixes slow network refresh

### DIFF
--- a/sphinx/service/features/notifications/feature-service-notification-firebase/src/main/java/chat/sphinx/feature_service_notification_firebase/FirebasePushNotificationRegistrar.kt
+++ b/sphinx/service/features/notifications/feature-service-notification-firebase/src/main/java/chat/sphinx/feature_service_notification_firebase/FirebasePushNotificationRegistrar.kt
@@ -61,15 +61,17 @@ internal class FirebasePushNotificationRegistrar(
             }
         } catch (e: Exception) {}
 
-        if (tokenFetchResponse.value is Response.Error) {
-            return tokenFetchResponse.value!!
-        }
-
-        return contactRepository.updateOwnerDeviceId(
-            DeviceId(
-                (tokenFetchResponse.value!! as Response.Success).value
-            )
-        )
+        return tokenFetchResponse.value?.let { response ->
+            @Exhaustive
+            when (response) {
+                is Response.Error -> {
+                    response
+                }
+                is Response.Success -> {
+                    contactRepository.updateOwnerDeviceId(DeviceId(response.value))
+                }
+            }
+        } ?: Response.Error(ResponseError("NotificationToken retrieved was null"))
     }
 
     init {


### PR DESCRIPTION
This PR fixes #173 by decoupling the notification token registration from the network refresh task such that it occurs once, and independently so if PlayServices are not present it will not hold up the network refresh request.