### PR TITLE
Make feature-service-notification-empty buildable

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -122,7 +122,10 @@ include ':sphinx:service:concepts:concept-service-media-player'
 include ':sphinx:service:features:media-player:feature-service-media-player-android'
 include ':sphinx:service:concepts:concept-service-notification'
 include ':sphinx:service:features:notifications:feature-service-notification-empty'
-include ':sphinx:service:features:notifications:feature-service-notification-firebase'
+final def googleServicesJson = file(new File(rootDir, 'sphinx/service/features/notifications/feature-service-notification-firebase/google-services.json'))
+if (googleServicesJson.exists()) {
+    include ':sphinx:service:features:notifications:feature-service-notification-firebase'
+}
 
 // Testing
 include ':sphinx:test:test-network-query'

--- a/sphinx/application/sphinx/build.gradle
+++ b/sphinx/application/sphinx/build.gradle
@@ -69,6 +69,8 @@ android {
 }
 
 dependencies {
+    final def googleServicesJson = file(new File(rootDir, 'sphinx/service/features/notifications/feature-service-notification-firebase/google-services.json'))
+
     implementation fileTree(dir: "libs", include: ["*.jar"])
     // KotlinAndroid
     implementation project(path: ':android:features:authentication:android-feature-authentication-core')
@@ -105,7 +107,7 @@ dependencies {
     implementation project(path: ':sphinx:service:features:media-player:feature-service-media-player-android')
 
     // See `/sphinx/service/features/notifications/README.md`
-    if (findProperty("SPHINX_COMPILE_PUSH_NOTIFICATION_TYPE") == "firebase") {
+    if (googleServicesJson.exists() && findProperty("SPHINX_COMPILE_PUSH_NOTIFICATION_TYPE") == "firebase") {
         // FirebaseMessaging
         implementation project(path: ':sphinx:service:features:notifications:feature-service-notification-firebase')
     } else {


### PR DESCRIPTION
When the google-services.json doesn't exist the build fails
This checks the existence of the file before including the firebase notification project