### PR TITLE
Fix for direct payments with template image

### DIFF
--- a/sphinx/application/common/wrappers/wrapper-message/src/main/java/chat/sphinx/wrapper_message/Message.kt
+++ b/sphinx/application/common/wrappers/wrapper-message/src/main/java/chat/sphinx/wrapper_message/Message.kt
@@ -37,10 +37,13 @@ inline fun Message.retrieveTextToShow(): String? =
 inline fun Message.retrieveImageUrlAndMessageMedia(): Pair<String, MessageMedia?>? {
     var mediaData: Pair<String, MessageMedia?>? = null
 
+    if (this.type.isDirectPayment()) {
+        return null
+    }
+
     giphyData?.let { giphyData ->
         mediaData = giphyData.retrieveImageUrlAndMessageMedia()
     } ?: messageMedia?.let { media ->
-
         if (media.mediaType.isImage && !isPaidMessage) {
 
             // always prefer loading a file if it exists over loading a url


### PR DESCRIPTION
Direct payments can contain template images. As we didn't implement that yet, when receiving a direct payment with image, the app was showing just an empty image bubble overlapping the direct payment information layout. I added a fix to prevent that until we work on the payment templates implementation