### PR TITLE
Fix Payment Request View Stat handling

### DIFF
--- a/sphinx/screens-detail/payments/payment-common/payment-common/src/main/java/chat/sphinx/payment_common/ui/PaymentViewModel.kt
+++ b/sphinx/screens-detail/payments/payment-common/payment-common/src/main/java/chat/sphinx/payment_common/ui/PaymentViewModel.kt
@@ -1,7 +1,6 @@
 package chat.sphinx.payment_common.ui
 
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavArgs
 import chat.sphinx.concept_repository_contact.ContactRepository
 import chat.sphinx.concept_repository_message.model.SendPayment
@@ -38,17 +37,9 @@ abstract class PaymentViewModel<ARGS: NavArgs, VS: ViewState<VS>>(
         ViewStateContainer(AmountViewState.Idle)
     }
 
-    protected val contactSharedFlow: SharedFlow<Contact?> = flow {
-        contactId?.let { contactId ->
-            emitAll(contactRepository.getContactById(contactId))
-        } ?: run {
-            emit(null)
-        }
-    }.distinctUntilChanged().shareIn(
-        viewModelScope,
-        SharingStarted.WhileSubscribed(2_000),
-        replay = 1,
-    )
+    protected suspend fun getContactOrNull(): Contact? {
+        return contactId?.let { id -> contactRepository.getContactById(id).firstOrNull() }
+    }
 
     abstract fun updateAmount(amountString: String)
 

--- a/sphinx/screens-detail/payments/payment-receive/payment-receive/src/main/java/chat/sphinx/payment_receive/ui/PaymentReceiveViewModel.kt
+++ b/sphinx/screens-detail/payments/payment-receive/payment-receive/src/main/java/chat/sphinx/payment_receive/ui/PaymentReceiveViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import chat.sphinx.concept_repository_contact.ContactRepository
 import chat.sphinx.concept_repository_lightning.LightningRepository
 import chat.sphinx.concept_repository_lightning.model.RequestPayment
-import chat.sphinx.kotlin_response.LoadResponse
 import chat.sphinx.kotlin_response.Response
 import chat.sphinx.payment_common.ui.PaymentSideEffect
 import chat.sphinx.payment_common.ui.PaymentViewModel
@@ -21,7 +20,7 @@ import io.matthewnelson.android_feature_navigation.util.navArgs
 import io.matthewnelson.android_feature_viewmodel.submitSideEffect
 import io.matthewnelson.android_feature_viewmodel.updateViewState
 import io.matthewnelson.concept_coroutines.CoroutineDispatchers
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.annotation.meta.Exhaustive
 import javax.inject.Inject
@@ -68,15 +67,14 @@ internal class PaymentReceiveViewModel @Inject constructor(
     }
 
     private suspend fun refreshViewState() {
-        contactSharedFlow.collect { contact ->
-            viewStateContainer.updateViewState(
-                if (contact != null) {
-                    PaymentReceiveViewState.ChatPaymentRequest(contact)
-                } else {
-                    PaymentReceiveViewState.RequestLightningPayment
-                }
-            )
-        }
+        val contact = getContactOrNull()
+        viewStateContainer.updateViewState(
+            if (contact != null) {
+                PaymentReceiveViewState.ChatPaymentRequest(contact)
+            } else {
+                PaymentReceiveViewState.RequestLightningPayment
+            }
+        )
     }
 
     fun requestPayment(message: String? = null) {
@@ -106,6 +104,9 @@ internal class PaymentReceiveViewModel @Inject constructor(
                             String.format(app.getString(R.string.amount_n_sats), requestPayment.amount),
                             false
                         )
+                        refreshViewState()
+                        delay(100L)
+                        updateAmount("")
                     }
                 }
             } else {

--- a/sphinx/screens-detail/payments/payment-send/payment-send/src/main/java/chat/sphinx/payment_send/ui/PaymentSendViewModel.kt
+++ b/sphinx/screens-detail/payments/payment-send/payment-send/src/main/java/chat/sphinx/payment_send/ui/PaymentSendViewModel.kt
@@ -28,7 +28,6 @@ import io.matthewnelson.android_feature_navigation.util.navArgs
 import io.matthewnelson.android_feature_viewmodel.submitSideEffect
 import io.matthewnelson.concept_coroutines.CoroutineDispatchers
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -75,15 +74,14 @@ internal class PaymentSendViewModel @Inject constructor(
 
     init {
         viewModelScope.launch(mainImmediate) {
-            contactSharedFlow.collect { contact ->
-                viewStateContainer.updateViewState(
-                    if (contact != null) {
-                        PaymentSendViewState.ChatPayment(contact)
-                    } else {
-                        PaymentSendViewState.KeySendPayment
-                    }
-                )
-            }
+            val contact = getContactOrNull()
+            viewStateContainer.updateViewState(
+                if (contact != null) {
+                    PaymentSendViewState.ChatPayment(contact)
+                } else {
+                    PaymentSendViewState.KeySendPayment
+                }
+            )
         }
     }
 


### PR DESCRIPTION
This PR removes the improper usage of SharedFlow within the view model (it was being collected indefinitely utilizing a WhileSubscribed + ShareIn extension). It also fixes ViewState handling where after navigating to display the QR code was not resetting the view state such that upon back press, the screen was locked up as processing network request.