### PR TITLE
Fix for long click message menu

### DIFF
--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
@@ -352,6 +352,7 @@ internal class MessageListAdapter<ARGS : NavArgs>(
                 viewModel.memeServerTokenHandler,
                 recyclerViewWidth,
                 viewState,
+                selectedMessageLongClickListener,
                 onSphinxInteractionListener
             )
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
@@ -238,6 +238,8 @@ internal class MessageListAdapter<ARGS : NavArgs>(
                     true
                 }
 
+                root.setOnLongClickListener(selectedMessageLongClickListener)
+
                 onSphinxInteractionListener = object: SphinxUrlSpan.OnInteractionListener(
                     selectedMessageLongClickListener) {
                     override fun onClick(url: String?) {

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
@@ -352,7 +352,6 @@ internal class MessageListAdapter<ARGS : NavArgs>(
                 viewModel.memeServerTokenHandler,
                 recyclerViewWidth,
                 viewState,
-                selectedMessageLongClickListener,
                 onSphinxInteractionListener
             )
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
@@ -1,7 +1,6 @@
 package chat.sphinx.chat_common.ui.viewstate.messageholder
 
 import android.view.Gravity
-import android.view.View
 import android.widget.ImageView
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -52,7 +51,6 @@ internal fun LayoutMessageHolderBinding.setView(
     memeServerTokenHandler: MemeServerTokenHandler,
     recyclerViewWidth: Px,
     viewState: MessageHolderViewState,
-    longClickListener: View.OnLongClickListener? = null,
     onSphinxInteractionListener: SphinxUrlSpan.OnInteractionListener? = null
 ) {
     for (job in holderJobs) {
@@ -81,7 +79,7 @@ internal fun LayoutMessageHolderBinding.setView(
 
         setStatusHeader(viewState.statusHeader)
         setDeletedMessageLayout(viewState.deletedMessage)
-        setBubbleBackground(viewState, recyclerViewWidth, longClickListener)
+        setBubbleBackground(viewState, recyclerViewWidth)
         setGroupActionIndicatorLayout(viewState.groupActionIndicator)
 
         if (viewState.background !is BubbleBackground.Gone) {
@@ -311,7 +309,6 @@ internal inline fun LayoutMessageHolderBinding.setBubbleDirectPaymentLayout(
 internal fun LayoutMessageHolderBinding.setBubbleBackground(
     viewState: MessageHolderViewState,
     holderWidth: Px,
-    longClickListener: View.OnLongClickListener?
 ) {
     if (viewState.background is BubbleBackground.Gone) {
 
@@ -325,8 +322,6 @@ internal fun LayoutMessageHolderBinding.setBubbleBackground(
 
         includeMessageHolderBubble.root.apply {
             visible
-
-            setOnLongClickListener(longClickListener)
 
             @DrawableRes
             val resId: Int? = when (viewState.background) {

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
@@ -1,6 +1,7 @@
 package chat.sphinx.chat_common.ui.viewstate.messageholder
 
 import android.view.Gravity
+import android.view.View
 import android.widget.ImageView
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -51,6 +52,7 @@ internal fun LayoutMessageHolderBinding.setView(
     memeServerTokenHandler: MemeServerTokenHandler,
     recyclerViewWidth: Px,
     viewState: MessageHolderViewState,
+    longClickListener: View.OnLongClickListener? = null,
     onSphinxInteractionListener: SphinxUrlSpan.OnInteractionListener? = null
 ) {
     for (job in holderJobs) {
@@ -79,7 +81,7 @@ internal fun LayoutMessageHolderBinding.setView(
 
         setStatusHeader(viewState.statusHeader)
         setDeletedMessageLayout(viewState.deletedMessage)
-        setBubbleBackground(viewState, recyclerViewWidth)
+        setBubbleBackground(viewState, recyclerViewWidth, longClickListener)
         setGroupActionIndicatorLayout(viewState.groupActionIndicator)
 
         if (viewState.background !is BubbleBackground.Gone) {
@@ -309,6 +311,7 @@ internal inline fun LayoutMessageHolderBinding.setBubbleDirectPaymentLayout(
 internal fun LayoutMessageHolderBinding.setBubbleBackground(
     viewState: MessageHolderViewState,
     holderWidth: Px,
+    longClickListener: View.OnLongClickListener?
 ) {
     if (viewState.background is BubbleBackground.Gone) {
 
@@ -322,6 +325,8 @@ internal fun LayoutMessageHolderBinding.setBubbleBackground(
 
         includeMessageHolderBubble.root.apply {
             visible
+
+            setOnLongClickListener(longClickListener)
 
             @DrawableRes
             val resId: Int? = when (viewState.background) {


### PR DESCRIPTION
Not showing for images and other message types (caused by link click listener implementation)