### PR TITLE
Sending attachments fixes

### DIFF
--- a/sphinx/application/data/features/feature-repository/src/main/java/chat/sphinx/feature_repository/util/Extensions.kt
+++ b/sphinx/application/data/features/feature-repository/src/main/java/chat/sphinx/feature_repository/util/Extensions.kt
@@ -324,6 +324,24 @@ fun TransactionCallbacks.upsertMessage(dto: MessageDto, queries: SphinxDatabaseQ
         ChatId(it)
     } ?: ChatId(ChatId.NULL_CHAT_ID.toLong())
 
+    dto.media_token?.let { mediaToken ->
+        dto.media_type?.let { mediaType ->
+
+            if (mediaToken.isEmpty() || mediaType.isEmpty()) return
+
+            queries.messageMediaUpsert(
+                dto.media_key?.toMediaKey(),
+                mediaType.toMediaType(),
+                MediaToken(mediaToken),
+                MessageId(dto.id),
+                chatId,
+                dto.mediaKeyDecrypted?.toMediaKeyDecrypted(),
+                dto.mediaLocalFile,
+            )
+
+        }
+    }
+
     queries.messageUpsert(
         dto.status.toMessageStatus(),
         dto.seenActual.toSeen(),
@@ -345,24 +363,6 @@ fun TransactionCallbacks.upsertMessage(dto: MessageDto, queries: SphinxDatabaseQ
         dto.message_content?.toMessageContent(),
         dto.messageContentDecrypted?.toMessageContentDecrypted(),
     )
-
-    dto.media_token?.let { mediaToken ->
-        dto.media_type?.let { mediaType ->
-
-            if (mediaToken.isEmpty() || mediaType.isEmpty()) return
-
-            queries.messageMediaUpsert(
-                dto.media_key?.toMediaKey(),
-                mediaType.toMediaType(),
-                MediaToken(mediaToken),
-                MessageId(dto.id),
-                chatId,
-                dto.mediaKeyDecrypted?.toMediaKeyDecrypted(),
-                dto.mediaLocalFile,
-            )
-
-        }
-    }
 }
 
 @Suppress("NOTHING_TO_INLINE")
@@ -394,4 +394,13 @@ inline fun TransactionCallbacks.deleteContactById(
     queries.contactDeleteById(contactId)
     queries.inviteDeleteByContactId(contactId)
     queries.dashboardDeleteById(contactId)
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun TransactionCallbacks.deleteMessageById(
+    messageId: MessageId,
+    queries: SphinxDatabaseQueries
+) {
+    queries.messageDeleteById(messageId)
+    queries.messageMediaDeleteById(messageId)
 }


### PR DESCRIPTION
- Upserting messageMedia before upserting message. This will prevent the attachment message record to be inserted before its media, which would cause the view to show the unsupported row for less than a second (since messages with type attachment with no media data are considered unsupported). This way, at the moment the message is inserted and collected by those listening to messages changes, the media data will be there to be parsed and set on message object
- Deleting messageMedia when deleting message. This applies mostly for provisional message delete. As we were not deleting messageMedia record when deleting provisional message, next time sending an image on the chat, the messageMedia with id = -1 was already there, and on the update of the upsert extension function, the local_file was not being updated, generating the row to always show the same old image while new image was being uploaded.
- Delay added on Socket message received for attachment messages: for some reason, the socket confirmation for attachments is coming before the sendMessage request returns. That causes 2 issues:
            **1.** Record is created on SocketMessageReceived with status RECEIVED, then updated to status CONFIRMED on request response. Causing the green bolt not to appear on row until going back to dashboard and in to chat again
            **2.** As localFile is set on messageMedia just on insert (not on update), if the message is first created on SocketMessageReceived (with no file data), and then updated on request response where localFile is not considered, then once upload finishes, the row was showing loading wheel and loading image from URL again instead of using the local cached file.  