### PR TITLE
Fix: Onboard step persisting data before successful token generation

### DIFF
--- a/sphinx/screens/splash/splash/src/main/java/chat/sphinx/splash/ui/SplashViewModel.kt
+++ b/sphinx/screens/splash/splash/src/main/java/chat/sphinx/splash/ui/SplashViewModel.kt
@@ -302,12 +302,6 @@ internal class SplashViewModel @Inject constructor(
             )
         }
 
-        val step1: OnBoardStep.Step1_Welcome? = onBoardStepHandler.persistOnBoardStep1Data(
-            relayUrl,
-            authToken,
-            inviterData
-        )
-
         networkQueryContact.generateToken(relayUrl, authToken, password, nodePubKey).collect { loadResponse ->
             @Exhaustive
             when (loadResponse) {
@@ -317,6 +311,12 @@ internal class SplashViewModel @Inject constructor(
                     submitSideEffect(SplashSideEffect.GenerateTokenFailed)
                 }
                 is Response.Success -> {
+
+                    val step1: OnBoardStep.Step1_Welcome? = onBoardStepHandler.persistOnBoardStep1Data(
+                        relayUrl,
+                        authToken,
+                        inviterData
+                    )
 
                     if (step1 == null) {
                         updateViewState(SplashViewState.HideLoadingWheel)


### PR DESCRIPTION
This PR moves the persisting of onboard step 1 data into the successful network request for generating an authentication token when pairing the client to one's node.

Fixes #280