### PR TITLE
Fix for hidden sent message header

### DIFF
--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/InitialHolderViewState.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/InitialHolderViewState.kt
@@ -35,7 +35,6 @@ sealed class InitialHolderViewState {
             imageLoader: ImageLoader<ImageView>,
             @ColorInt color: Int?,
         ): Disposable? {
-            statusHeader.root.gone
             textViewInitials.gone
             imageViewPicture.gone
 


### PR DESCRIPTION
The InitialHolderViewState was being set to None for Sent message (which is correct since sent messages shouldn't show initials circle nor sender image view). The problem was that the statusHeader was being set to `gone` on `setInitialHolder` of `InitialHolderViewState.None`

This issue was present on user-colors branch, but then I pushed a fix for it. So I guess it was caused by the merge