### PR TITLE
Bubble adaptable width

### DIFF
--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListAdapter.kt
@@ -233,14 +233,13 @@ internal class MessageListAdapter<ARGS : NavArgs>(
                 val selectedMessageLongClickListener = OnLongClickListener { v ->
                     SelectedMessageViewState.SelectedMessage.instantiate(
                         messageHolderViewState = currentViewState,
-                        holderYPosTop = Px(binding.root.y),
+                        holderYPosTop = Px(binding.root.y + binding.includeMessageHolderBubble.root.y),
                         holderHeight = Px(binding.root.measuredHeight.toFloat()),
                         holderWidth = Px(binding.root.measuredWidth.toFloat()),
                         bubbleXPosStart = Px(root.x),
                         bubbleWidth = Px(root.measuredWidth.toFloat()),
                         bubbleHeight = Px(root.measuredHeight.toFloat()),
                         headerHeight = headerHeight,
-                        statusHeaderHeight = Px(binding.includeMessageStatusHeader.root.measuredHeight.toFloat()),
                         recyclerViewWidth = recyclerViewWidth,
                         screenHeight = screenHeight
                     ).let { vs ->

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListFooterAdapter.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/adapters/MessageListFooterAdapter.kt
@@ -1,0 +1,33 @@
+package chat.sphinx.chat_common.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import chat.sphinx.chat_common.databinding.LayoutMessageListFooterBinding
+
+/**
+ * Needed in order to have the last item of the RecyclerView
+ * be able to scroll up over the device's navigation bar.
+ * */
+internal class MessageListFooterAdapter: RecyclerView.Adapter<MessageListFooterAdapter.FooterViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FooterViewHolder {
+        val binding = LayoutMessageListFooterBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+
+        return FooterViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: FooterViewHolder, position: Int) {}
+
+    override fun getItemCount(): Int {
+        return 1
+    }
+
+    inner class FooterViewHolder(
+        binding: LayoutMessageListFooterBinding
+    ): RecyclerView.ViewHolder(binding.root)
+}

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
@@ -622,11 +622,12 @@ abstract class ChatFragment<
         }
     }
 
-    protected fun scrollToBottom(
+    private fun scrollToBottom(
         callback: () -> Unit,
         replyingToMessage: Boolean = false
     ) {
-        (recyclerView.adapter as MessageListAdapter<*>).scrollToBottomIfNeeded(callback, replyingToMessage)
+        ((recyclerView.adapter as ConcatAdapter).adapters.first() as MessageListAdapter<*>)
+            .scrollToBottomIfNeeded(callback, replyingToMessage)
     }
 
     override fun onStart() {

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
@@ -939,11 +939,6 @@ abstract class ChatFragment<
                         selectedMessageHolderBinding.apply {
                             root.y = viewState.holderYPos.value
 
-                            setViewsFixedWidth(
-                                viewState.messageHolderViewState,
-                                viewState.recyclerViewWidth
-                            )
-
                             setView(
                                 lifecycleScope,
                                 holderJobs,

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
@@ -477,7 +477,6 @@ abstract class ChatFragment<
                 }
             }
         }
-//        selectedMessageHolderBinding.root.setBackgroundColor(ContextCompat.getColor(binding.root.context, R.color.badgeRed))
         selectedMessageHolderBinding.includeMessageHolderBubble.root.setOnClickListener {
             viewModel
         }

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/ChatFragment.kt
@@ -980,27 +980,55 @@ abstract class ChatFragment<
 
                             this@message.includeLayoutSelectedMessageMenu.apply {
                                 spaceSelectedMessageMenuArrowTop.goneIfFalse(!viewState.showMenuTop)
-                                imageViewSelectedMessageMenuArrowTop.goneIfFalse(!viewState.showMenuTop)
+                                layoutConstraintSelectedMessageMenuArrowTopContainer.goneIfFalse(!viewState.showMenuTop)
 
                                 spaceSelectedMessageMenuArrowBottom.goneIfFalse(viewState.showMenuTop)
-                                imageViewSelectedMessageMenuArrowBottom.goneIfFalse(viewState.showMenuTop)
+                                layoutConstraintSelectedMessageMenuArrowBottomContainer.goneIfFalse(viewState.showMenuTop)
+
+                                imageViewSelectedMessageMenuArrowBottomCenter.goneIfFalse(false)
+                                imageViewSelectedMessageMenuArrowBottomRight.goneIfFalse(false)
+                                imageViewSelectedMessageMenuArrowBottomLeft.goneIfFalse(false)
+
+                                imageViewSelectedMessageMenuArrowTopCenter.goneIfFalse(false)
+                                imageViewSelectedMessageMenuArrowTopRight.goneIfFalse(false)
+                                imageViewSelectedMessageMenuArrowTopLeft.goneIfFalse(false)
                             }
 
-                            this@message.includeLayoutSelectedMessageMenu.root.apply menu@ {
+                            this@message.includeLayoutSelectedMessageMenu.apply menu@ {
 
-                                this@menu.y = if (viewState.showMenuTop) {
+                                this@menu.root.y = if (viewState.showMenuTop) {
                                     viewState.holderYPos.value -
                                             (resources.getDimension(R.dimen.selected_message_menu_item_height) * (viewState.messageHolderViewState.selectionMenuItems?.size ?: 0)) -
-                                            Dp(10F).toPx(context).value
+                                            Dp(10F).toPx(root.context).value
                                 } else {
                                     viewState.holderYPos.value +
                                             viewState.bubbleHeight.value +
-                                            Dp(10F).toPx(context).value
+                                            Dp(10F).toPx(root.context).value
                                 }
-                                val menuWidth = resources.getDimension(R.dimen.selected_message_menu_width)
 
-                                // TODO: Handle small bubbles better
-                                this@menu.x = viewState.bubbleCenterXPos.value - (menuWidth / 2F)
+                                val menuWidth = resources.getDimension(R.dimen.selected_message_menu_width)
+                                var menuXPos = viewState.bubbleCenterXPos.value - (menuWidth / 2F)
+
+                                when {
+                                    (menuXPos + menuWidth > viewState.recyclerViewWidth.value) -> {
+                                        menuXPos = viewState.recyclerViewWidth.value - menuWidth - Dp(16F).toPx(root.context).value
+
+                                        this@menu.imageViewSelectedMessageMenuArrowBottomRight.visible
+                                        this@menu.imageViewSelectedMessageMenuArrowTopRight.visible
+                                    }
+                                    (menuXPos < 0F) -> {
+                                        menuXPos = Dp(16F).toPx(root.context).value
+
+                                        this@menu.imageViewSelectedMessageMenuArrowBottomLeft.visible
+                                        this@menu.imageViewSelectedMessageMenuArrowTopLeft.visible
+                                    }
+                                    else -> {
+                                        this@menu.imageViewSelectedMessageMenuArrowBottomCenter.visible
+                                        this@menu.imageViewSelectedMessageMenuArrowTopCenter.visible
+                                    }
+                                }
+
+                                this@menu.root.x = menuXPos
                             }
                             this@message.setMenuColor(viewState.messageHolderViewState)
                             this@message.setMenuItems(viewState.messageHolderViewState.selectionMenuItems)

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/BubbleBackground.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/BubbleBackground.kt
@@ -1,11 +1,6 @@
 package chat.sphinx.chat_common.ui.viewstate.messageholder
 
 internal sealed class BubbleBackground {
-
-    companion object {
-        const val SPACE_WIDTH_MULTIPLE: Float = 0.2F
-    }
-
     /**
      * If [setSpacingEqual] is false, will set the spacing based on if
      * it is a received or sent message.

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
@@ -439,8 +439,12 @@ internal fun LayoutMessageHolderBinding.setViewsFixedWidth(
 ) {
     val viewsFixedMinWidth = root.context.resources
         .getDimensionPixelSize(R.dimen.message_views_fixed_min_width)
-    val viewsFixedWidth = (viewsFixedMinWidth.toDouble()
-        .coerceAtLeast(holderWidth.value * 0.7)).toInt()
+    val viewsFixedMaxWidth = root.context.resources
+        .getDimensionPixelSize(R.dimen.message_views_fixed_max_width)
+
+    var viewsFixedWidth:Int = (holderWidth.value * 0.7).toInt()
+    viewsFixedWidth = viewsFixedWidth.coerceAtLeast(viewsFixedMinWidth)
+    viewsFixedWidth = viewsFixedWidth.coerceAtMost(viewsFixedMaxWidth)
 
     includeMessageHolderBubble.apply {
         textViewPaidMessageText.maxWidth = viewsFixedWidth

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
@@ -102,11 +102,8 @@ internal fun LayoutMessageHolderBinding.setView(
             lifecycleScope,
             userColorsHelper,
         )
-        setBubbleBackground(viewState, recyclerViewWidth)
-
-        if (!viewState.viewsWidthSet) {
-            setViewsFixedWidth(viewState, recyclerViewWidth)
-        }
+        setBubbleBackground(viewState)
+        setViewsFixedWidth(recyclerViewWidth)
 
         setDeletedMessageLayout(viewState.deletedMessage)
         setGroupActionIndicatorLayout(viewState.groupActionIndicator)
@@ -362,7 +359,6 @@ internal inline fun LayoutMessageHolderBinding.setBubbleDirectPaymentLayout(
 @MainThread
 internal fun LayoutMessageHolderBinding.setBubbleBackground(
     viewState: MessageHolderViewState,
-    holderWidth: Px,
 ) {
     if (viewState.background is BubbleBackground.Gone) {
         includeMessageHolderBubble.root.gone
@@ -403,9 +399,6 @@ internal fun LayoutMessageHolderBinding.setBubbleBackground(
                     /* will never make it here as this is already checked for */
                     null
                 }
-                else -> {
-                    null
-                }
             }
 
             resId?.let { setBackgroundResource(it) }
@@ -434,7 +427,6 @@ internal fun LayoutMessageHolderBinding.setBubbleBackground(
 
 @MainThread
 internal fun LayoutMessageHolderBinding.setViewsFixedWidth(
-    viewState: MessageHolderViewState,
     holderWidth: Px,
 ) {
     val viewsFixedMinWidth = root.context.resources
@@ -463,14 +455,11 @@ internal fun LayoutMessageHolderBinding.setViewsFixedWidth(
         includeMessageTypeCallInvite.root.updateLayoutParams { width = viewsFixedWidth }
         includeMessageTypeInvoice.root.updateLayoutParams { width = viewsFixedWidth }
         includeMessageTypeBotResponse.root.updateLayoutParams { width = viewsFixedWidth }
-        includeMessageTypeBoost.root.updateLayoutParams { width = viewsFixedWidth }
 
         includeMessageLinkPreviewContact.root.updateLayoutParams { width = viewsFixedWidth }
         includeMessageLinkPreviewTribe.root.updateLayoutParams { width = viewsFixedWidth }
         includeMessageLinkPreviewUrl.root.updateLayoutParams { width = viewsFixedWidth }
     }
-
-    viewState.viewsWidthSet = true
 }
 
 @MainThread

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/HolderBindingExtensions.kt
@@ -446,8 +446,7 @@ internal fun LayoutMessageHolderBinding.setViewsFixedWidth(
         includePaidMessageReceivedDetailsHolder.root.updateLayoutParams { width = viewsFixedWidth }
 
         includeMessageReply.root.updateLayoutParams { width = viewsFixedWidth }
-
-        includeMessageTypeDirectPayment.root.updateLayoutParams { width = viewsFixedWidth }
+        
         includeMessageTypeImageAttachment.root.updateLayoutParams { width = viewsFixedWidth }
         includeMessageTypeFileAttachment.root.updateLayoutParams { width = viewsFixedWidth }
         includeMessageTypeAudioAttachment.root.updateLayoutParams { width = viewsFixedWidth }

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/MessageHolderViewState.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/MessageHolderViewState.kt
@@ -57,8 +57,6 @@ internal sealed class MessageHolderViewState(
         }
     }
 
-    var viewsWidthSet: Boolean = false
-
     val unsupportedMessageType: LayoutState.Bubble.ContainerThird.UnsupportedMessageType? by lazy(LazyThreadSafetyMode.NONE) {
         if (
             unsupportedMessageTypes.contains(message.type) &&

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/MessageHolderViewState.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/messageholder/MessageHolderViewState.kt
@@ -43,7 +43,7 @@ internal sealed class MessageHolderViewState(
     private val messageSenderName: (Message) -> String,
     private val accountOwner: () -> Contact,
     private val previewProvider: suspend (link: MessageLinkPreview) -> LayoutState.Bubble.ContainerThird.LinkPreview?,
-    private val paidTextAttachmentContentProvider: suspend (message: Message) -> LayoutState.Bubble.ContainerThird.Message?
+    private val paidTextAttachmentContentProvider: suspend (message: Message) -> LayoutState.Bubble.ContainerThird.Message?,
 ) {
 
     companion object {
@@ -56,6 +56,8 @@ internal sealed class MessageHolderViewState(
             )
         }
     }
+
+    var viewsWidthSet: Boolean = false
 
     val unsupportedMessageType: LayoutState.Bubble.ContainerThird.UnsupportedMessageType? by lazy(LazyThreadSafetyMode.NONE) {
         if (

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/selected/MenuItemBindingExtensions.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/selected/MenuItemBindingExtensions.kt
@@ -25,17 +25,33 @@ internal inline fun LayoutSelectedMessageBinding.setMenuColor(viewState: Message
             is MessageHolderViewState.Received -> {
                 layoutConstraintSelectedMessageMenuItemContainer
                     .setBackgroundResource(R.drawable.background_selected_received_message_menu)
-                imageViewSelectedMessageMenuArrowTop
+                imageViewSelectedMessageMenuArrowTopCenter
                     .setBackgroundResource(R.drawable.selected_received_message_top_arrow)
-                imageViewSelectedMessageMenuArrowBottom
+                imageViewSelectedMessageMenuArrowBottomCenter
+                    .setBackgroundResource(R.drawable.selected_received_message_bottom_arrow)
+                imageViewSelectedMessageMenuArrowTopRight
+                    .setBackgroundResource(R.drawable.selected_received_message_top_arrow)
+                imageViewSelectedMessageMenuArrowBottomRight
+                    .setBackgroundResource(R.drawable.selected_received_message_bottom_arrow)
+                imageViewSelectedMessageMenuArrowTopLeft
+                    .setBackgroundResource(R.drawable.selected_received_message_top_arrow)
+                imageViewSelectedMessageMenuArrowBottomLeft
                     .setBackgroundResource(R.drawable.selected_received_message_bottom_arrow)
             }
             is MessageHolderViewState.Sent -> {
                 layoutConstraintSelectedMessageMenuItemContainer
                     .setBackgroundResource(R.drawable.background_selected_sent_message_menu)
-                imageViewSelectedMessageMenuArrowTop
+                imageViewSelectedMessageMenuArrowTopCenter
                     .setBackgroundResource(R.drawable.selected_sent_message_top_arrow)
-                imageViewSelectedMessageMenuArrowBottom
+                imageViewSelectedMessageMenuArrowBottomCenter
+                    .setBackgroundResource(R.drawable.selected_sent_message_bottom_arrow)
+                imageViewSelectedMessageMenuArrowTopRight
+                    .setBackgroundResource(R.drawable.selected_sent_message_top_arrow)
+                imageViewSelectedMessageMenuArrowBottomRight
+                    .setBackgroundResource(R.drawable.selected_sent_message_bottom_arrow)
+                imageViewSelectedMessageMenuArrowTopLeft
+                    .setBackgroundResource(R.drawable.selected_sent_message_top_arrow)
+                imageViewSelectedMessageMenuArrowBottomLeft
                     .setBackgroundResource(R.drawable.selected_sent_message_bottom_arrow)
             }
         }

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/selected/SelectedMessageViewState.kt
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/java/chat/sphinx/chat_common/ui/viewstate/selected/SelectedMessageViewState.kt
@@ -14,7 +14,6 @@ internal sealed class SelectedMessageViewState: ViewState<SelectedMessageViewSta
         val holderYPos: Px,
         val bubbleCenterXPos: Px,
         val bubbleHeight: Px,
-        val statusHeaderHeight: Px,
         val recyclerViewWidth: Px,
         val showMenuTop: Boolean,
     ): SelectedMessageViewState() {
@@ -34,8 +33,6 @@ internal sealed class SelectedMessageViewState: ViewState<SelectedMessageViewSta
                 bubbleWidth: Px,
 
                 headerHeight: Px,
-
-                statusHeaderHeight: Px,
 
                 recyclerViewWidth: Px,
 
@@ -58,7 +55,6 @@ internal sealed class SelectedMessageViewState: ViewState<SelectedMessageViewSta
                     spaceTop,
                     bubbleWidth.divideBy(2F).add(bubbleXPosStart).add(margin),
                     bubbleHeight,
-                    statusHeaderHeight,
                     recyclerViewWidth,
                     spaceTop.isGreaterThanOrEqualTo(spaceBottom)
                 )

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_boost.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_boost.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:paddingVertical="@dimen/default_list_row_padding_vertical"
     android:paddingStart="@dimen/default_list_row_padding_vertical"
@@ -24,13 +24,14 @@
     <include
         android:id="@+id/include_boost_amount_text_group"
         layout="@layout/layout_text_sats_amount"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_marginHorizontal="@dimen/default_half_layout_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/include_boost_reactions_group"
         app:layout_constraintStart_toEndOf="@+id/image_view_boost_message_icon"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="2 000"/>
 
     <!-- Boost Reactions -->
     <include

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder.xml
@@ -41,44 +41,23 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
-    <!-- width is programmatically set depending on sender -->
-    <Space
-        android:id="@+id/space_message_holder_left"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:layout_width="@dimen/message_holder_space_width_left"
-        tools:visibility="visible" />
-
-    <!-- width is programmatically set depending on sender -->
-    <Space
-        android:id="@+id/space_message_holder_right"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:layout_width="80dp"
-        tools:visibility="visible" />
-
-
     <include
         android:id="@+id/include_deleted_message"
         layout="@layout/layout_deleted_message"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toStartOf="@+id/space_message_holder_right"
-        app:layout_constraintStart_toEndOf="@+id/space_message_holder_left"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="gone" />
 
     <include
         android:id="@+id/include_message_holder_bubble"
         layout="@layout/layout_message_holder_bubble"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toStartOf="@+id/space_message_holder_right"
-        app:layout_constraintStart_toEndOf="@+id/space_message_holder_left"
+        app:layout_constraintEnd_toStartOf="@+id/sent_bubble_arrow"
+        app:layout_constraintStart_toEndOf="@+id/received_bubble_arrow"
         app:layout_constraintTop_toBottomOf="@+id/include_message_status_header"
         tools:visibility="visible" />
 
@@ -87,7 +66,8 @@
         android:layout_width="4dp"
         android:layout_height="10dp"
         android:src="@drawable/received_bubble_arrow"
-        app:layout_constraintEnd_toStartOf="@+id/include_message_holder_bubble"
+        android:layout_marginLeft="@dimen/default_small_layout_margin"
+        app:layout_constraintStart_toEndOf="@+id/include_message_holder_chat_image_initial_holder"
         app:layout_constraintTop_toTopOf="@+id/include_message_holder_bubble"
         tools:visibility="visible" />
 
@@ -96,7 +76,7 @@
         android:layout_width="6dp"
         android:layout_height="10dp"
         android:src="@drawable/sent_bubble_arrow"
-        app:layout_constraintStart_toEndOf="@+id/include_message_holder_bubble"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/include_message_holder_bubble"
         tools:visibility="visible" />
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder.xml
@@ -36,8 +36,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/default_half_layout_margin"
-        app:layout_constraintEnd_toEndOf="@id/include_message_holder_bubble"
-        app:layout_constraintStart_toStartOf="@id/include_message_holder_bubble"
+        app:layout_constraintEnd_toStartOf="@+id/sent_bubble_arrow"
+        app:layout_constraintStart_toEndOf="@+id/received_bubble_arrow"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
@@ -2,47 +2,55 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     tools:background="@drawable/background_message_bubble_received_last">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_constraint_message_bubble_container_first"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <!--  Replies  -->
         <include
             android:id="@+id/include_message_reply"
             layout="@layout/layout_message_reply"
-            tools:visibility="gone" />
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
+            tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_constraint_message_bubble_container_second"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/layout_constraint_message_bubble_container_first">
 
         <!--   Status Row for Paid Message Sent  -->
         <include
             android:id="@+id/include_paid_message_sent_status_details"
             layout="@layout/layout_paid_message_sent"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="gone" />
 
         <!--   Direct Payment Message  -->
         <include
             android:id="@+id/include_message_type_direct_payment"
             layout="@layout/layout_message_type_direct_payment"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="visible" />
 
         <!--  Image Attachment  -->
         <include
             android:id="@+id/include_message_type_image_attachment"
             layout="@layout/layout_message_type_attachment_image"
-            android:layout_width="match_parent"
+            android:layout_width="300dp"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/include_message_type_direct_payment"
             tools:visibility="visible" />
@@ -51,12 +59,16 @@
         <include
             android:id="@+id/include_message_type_file_attachment"
             layout="@layout/layout_message_type_attachment_file"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="gone" />
 
         <!--  Audio Attachment  -->
         <include
             android:id="@+id/include_message_type_audio_attachment"
             layout="@layout/layout_message_type_attachment_audio"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="gone" />
 
 
@@ -64,6 +76,8 @@
         <include
             android:id="@+id/include_message_type_video_attachment"
             layout="@layout/layout_message_type_attachment_video"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="gone" />
 
 
@@ -71,6 +85,8 @@
         <include
             android:id="@+id/include_message_type_call_invite"
             layout="@layout/layout_message_type_call_invite"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="gone" />
 
 
@@ -78,17 +94,24 @@
         <include
             android:id="@+id/include_message_type_invoice"
             layout="@layout/layout_message_type_invoice"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="gone" />
 
         <!--  Podcast boost  -->
         <include
             android:id="@+id/include_message_type_podcast_boost"
             layout="@layout/layout_message_type_podcast_boost"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="@dimen/message_type_boost_min_width"
             tools:visibility="gone" />
 
         <include
             android:id="@+id/include_message_type_bot_response"
             layout="@layout/layout_message_type_bot_response"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
             tools:visibility="gone" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
@@ -96,34 +119,38 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_constraint_message_bubble_container_third"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/layout_constraint_message_bubble_container_second">
 
         <include
             android:id="@+id/include_unsupported_message_type_placeholder"
             layout="@layout/layout_unsupported_message_type_placeholder"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/text_view_message_text"
             style="@style/chat_message_body_text"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:maxWidth="300dp"
             android:paddingHorizontal="@dimen/default_layout_margin"
             android:paddingVertical="@dimen/default_inner_spacing_list_item_title"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@+id/include_unsupported_message_type_placeholder"
+            app:layout_constraintStart_toStartOf="parent"
             tools:text="Contrary to popular belief"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/text_view_paid_message_text"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:maxWidth="300dp"
             android:fontFamily="@font/roboto_italic"
             android:textSize="@dimen/chat_paid_message_notice_text_size"
             android:textColor="@color/textMessages"
@@ -131,6 +158,7 @@
             android:paddingVertical="@dimen/default_inner_spacing_list_item_title"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@+id/include_unsupported_message_type_placeholder"
+            app:layout_constraintStart_toStartOf="parent"
             tools:text="@string/paid_message_pay_to_unlock"
             tools:visibility="gone" />
 
@@ -138,17 +166,17 @@
         <include
             android:id="@+id/include_message_link_preview_contact"
             layout="@layout/layout_message_link_preview_contact"
-            android:layout_width="match_parent"
+            android:layout_width="300dp"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
 
         <!-- Tribe link preview  -->
         <include
             android:id="@+id/include_message_link_preview_tribe"
             layout="@layout/layout_message_link_preview_tribe"
-            android:layout_width="match_parent"
+            android:layout_width="300dp"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
             tools:visibility="gone" />
@@ -157,33 +185,34 @@
         <include
             android:id="@+id/include_message_link_preview_url"
             layout="@layout/layout_message_link_preview_url"
-            android:layout_width="match_parent"
+            android:layout_width="300dp"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
-            tools:visibility="gone" />
+            tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_constraint_message_bubble_container_forth"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/layout_constraint_message_bubble_container_third">
 
         <!-- Boost Details -->
         <include
             android:id="@+id/include_message_type_boost"
             layout="@layout/layout_message_boost"
-            android:layout_width="match_parent"
+            android:layout_width="300dp"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
         <!-- Paid Message Information -->
         <include
             android:id="@+id/include_paid_message_received_details_holder"
             layout="@layout/layout_paid_message_received"
-            android:layout_width="match_parent"
+            android:layout_width="300dp"
             android:layout_height="@dimen/paid_attachment_view_height"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/include_message_type_boost"

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
@@ -17,7 +17,7 @@
         <include
             android:id="@+id/include_message_reply"
             layout="@layout/layout_message_reply"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             tools:visibility="visible" />
 
@@ -34,7 +34,7 @@
         <include
             android:id="@+id/include_paid_message_sent_status_details"
             layout="@layout/layout_paid_message_sent"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -42,24 +42,24 @@
         <include
             android:id="@+id/include_message_type_direct_payment"
             layout="@layout/layout_message_type_direct_payment"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
         <!--  Image Attachment  -->
         <include
             android:id="@+id/include_message_type_image_attachment"
             layout="@layout/layout_message_type_attachment_image"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/include_message_type_direct_payment"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
         <!--  File Attachment  -->
         <include
             android:id="@+id/include_message_type_file_attachment"
             layout="@layout/layout_message_type_attachment_file"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -67,16 +67,16 @@
         <include
             android:id="@+id/include_message_type_audio_attachment"
             layout="@layout/layout_message_type_attachment_audio"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
-            tools:visibility="gone" />
+            tools:visibility="visible" />
 
 
         <!--  Video Attachment  -->
         <include
             android:id="@+id/include_message_type_video_attachment"
             layout="@layout/layout_message_type_attachment_video"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -85,7 +85,7 @@
         <include
             android:id="@+id/include_message_type_call_invite"
             layout="@layout/layout_message_type_call_invite"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -94,7 +94,7 @@
         <include
             android:id="@+id/include_message_type_invoice"
             layout="@layout/layout_message_type_invoice"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -110,7 +110,7 @@
         <include
             android:id="@+id/include_message_type_bot_response"
             layout="@layout/layout_message_type_bot_response"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -137,7 +137,7 @@
             style="@style/chat_message_body_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:maxWidth="300dp"
+            android:maxWidth="@dimen/message_views_fixed_min_width"
             android:paddingHorizontal="@dimen/default_layout_margin"
             android:paddingVertical="@dimen/default_inner_spacing_list_item_title"
             android:visibility="gone"
@@ -150,7 +150,7 @@
             android:id="@+id/text_view_paid_message_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:maxWidth="300dp"
+            android:maxWidth="@dimen/message_views_fixed_min_width"
             android:fontFamily="@font/roboto_italic"
             android:textSize="@dimen/chat_paid_message_notice_text_size"
             android:textColor="@color/textMessages"
@@ -166,7 +166,7 @@
         <include
             android:id="@+id/include_message_link_preview_contact"
             layout="@layout/layout_message_link_preview_contact"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
             tools:visibility="gone" />
@@ -176,7 +176,7 @@
         <include
             android:id="@+id/include_message_link_preview_tribe"
             layout="@layout/layout_message_link_preview_tribe"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
             tools:visibility="gone" />
@@ -185,7 +185,7 @@
         <include
             android:id="@+id/include_message_link_preview_url"
             layout="@layout/layout_message_link_preview_url"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
             tools:visibility="visible" />
@@ -203,7 +203,7 @@
         <include
             android:id="@+id/include_message_type_boost"
             layout="@layout/layout_message_boost"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
             tools:visibility="gone" />
@@ -212,7 +212,7 @@
         <include
             android:id="@+id/include_paid_message_received_details_holder"
             layout="@layout/layout_paid_message_received"
-            android:layout_width="300dp"
+            android:layout_width="@dimen/message_views_fixed_min_width"
             android:layout_height="@dimen/paid_attachment_view_height"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/include_message_type_boost"

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
@@ -203,10 +203,10 @@
         <include
             android:id="@+id/include_message_type_boost"
             layout="@layout/layout_message_boost"
-            android:layout_width="@dimen/message_views_fixed_max_width"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="gone" />
+            tools:visibility="visible" />
 
         <!-- Paid Message Information -->
         <include

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
@@ -17,7 +17,7 @@
         <include
             android:id="@+id/include_message_reply"
             layout="@layout/layout_message_reply"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="visible" />
 
@@ -34,7 +34,7 @@
         <include
             android:id="@+id/include_paid_message_sent_status_details"
             layout="@layout/layout_paid_message_sent"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -42,7 +42,7 @@
         <include
             android:id="@+id/include_message_type_direct_payment"
             layout="@layout/layout_message_type_direct_payment"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -50,7 +50,7 @@
         <include
             android:id="@+id/include_message_type_image_attachment"
             layout="@layout/layout_message_type_attachment_image"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/include_message_type_direct_payment"
             tools:visibility="gone" />
@@ -59,7 +59,7 @@
         <include
             android:id="@+id/include_message_type_file_attachment"
             layout="@layout/layout_message_type_attachment_file"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -67,16 +67,16 @@
         <include
             android:id="@+id/include_message_type_audio_attachment"
             layout="@layout/layout_message_type_attachment_audio"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
 
         <!--  Video Attachment  -->
         <include
             android:id="@+id/include_message_type_video_attachment"
             layout="@layout/layout_message_type_attachment_video"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -85,7 +85,7 @@
         <include
             android:id="@+id/include_message_type_call_invite"
             layout="@layout/layout_message_type_call_invite"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -94,7 +94,7 @@
         <include
             android:id="@+id/include_message_type_invoice"
             layout="@layout/layout_message_type_invoice"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -110,7 +110,7 @@
         <include
             android:id="@+id/include_message_type_bot_response"
             layout="@layout/layout_message_type_bot_response"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 
@@ -137,7 +137,7 @@
             style="@style/chat_message_body_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:maxWidth="@dimen/message_views_fixed_min_width"
+            android:maxWidth="@dimen/message_views_fixed_max_width"
             android:paddingHorizontal="@dimen/default_layout_margin"
             android:paddingVertical="@dimen/default_inner_spacing_list_item_title"
             android:visibility="gone"
@@ -150,7 +150,7 @@
             android:id="@+id/text_view_paid_message_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:maxWidth="@dimen/message_views_fixed_min_width"
+            android:maxWidth="@dimen/message_views_fixed_max_width"
             android:fontFamily="@font/roboto_italic"
             android:textSize="@dimen/chat_paid_message_notice_text_size"
             android:textColor="@color/textMessages"
@@ -166,7 +166,7 @@
         <include
             android:id="@+id/include_message_link_preview_contact"
             layout="@layout/layout_message_link_preview_contact"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
             tools:visibility="gone" />
@@ -176,7 +176,7 @@
         <include
             android:id="@+id/include_message_link_preview_tribe"
             layout="@layout/layout_message_link_preview_tribe"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
             tools:visibility="gone" />
@@ -185,7 +185,7 @@
         <include
             android:id="@+id/include_message_link_preview_url"
             layout="@layout/layout_message_link_preview_url"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/text_view_message_text"
             tools:visibility="visible" />
@@ -203,7 +203,7 @@
         <include
             android:id="@+id/include_message_type_boost"
             layout="@layout/layout_message_boost"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
             tools:visibility="gone" />
@@ -212,7 +212,7 @@
         <include
             android:id="@+id/include_paid_message_received_details_holder"
             layout="@layout/layout_paid_message_received"
-            android:layout_width="@dimen/message_views_fixed_min_width"
+            android:layout_width="@dimen/message_views_fixed_max_width"
             android:layout_height="@dimen/paid_attachment_view_height"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/include_message_type_boost"

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_holder_bubble.xml
@@ -42,7 +42,7 @@
         <include
             android:id="@+id/include_message_type_direct_payment"
             layout="@layout/layout_message_type_direct_payment"
-            android:layout_width="@dimen/message_views_fixed_max_width"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:visibility="gone" />
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_list_footer.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_list_footer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/default_layout_margin"
+    android:background="@color/body">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_constraint_message_list_footer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_status_header.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_status_header.xml
@@ -156,11 +156,11 @@
         android:id="@+id/layout_constraint_message_status_sent_failed_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/default_double_layout_margin"
+        android:layout_marginEnd="@dimen/default_layout_margin"
         android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintEnd_toStartOf="@+id/layout_constraint_message_status_sent_container">
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/text_view_message_status_sent_failed_icon"

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_audio.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_audio.xml
@@ -4,79 +4,99 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/message_type_audio_attachment_height"
+    android:layout_height="wrap_content"
     android:visibility="gone"
-    tools:layout_height="@dimen/message_type_audio_attachment_height"
-    tools:layout_width="300dp"
     tools:visibility="visible">
 
+    <SeekBar
+        android:id="@+id/seek_bar_attachment_audio"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:progressTint="@color/receivedIcon"
+        android:thumbTint="@color/receivedIcon"
+        android:layout_marginHorizontal="@dimen/audio_message_seek_bar_margin_horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:progress="20" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_constraint_attachment_audio_play_button_group"
-        android:layout_width="50dp"
-        android:layout_height="62dp"
+        android:layout_width="@dimen/audio_button_play_pause_width"
+        android:layout_height="@dimen/message_type_audio_attachment_height"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/seek_bar_attachment_audio"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/button_attachment_audio_icon_play_pause_button"
-            android:layout_width="@dimen/audio_button_play_pause_width"
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/text_view_attachment_audio_failure"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:fontFamily="@font/material_icons_regular"
             android:gravity="center"
+            android:fontFamily="@font/material_icons_regular"
+            android:text="@string/material_icon_name_error"
+            android:textColor="@color/badgeRed"
+            android:textSize="@dimen/audio_button_play_pause_text_size"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="gone"/>
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/text_view_attachment_play_pause_button"
+            android:layout_width="@dimen/audio_button_play_pause_width"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:fontFamily="@font/material_icons_regular"
             android:text="@string/material_icon_name_play_button"
-            android:textSize="@dimen/icon_play_pause_button_text_size"
-            app:layout_constraintBottom_toBottomOf="@id/layout_constraint_attachment_audio_play_button_group"
-            app:layout_constraintEnd_toEndOf="@id/layout_constraint_attachment_audio_play_button_group"
-            app:layout_constraintStart_toStartOf="@id/layout_constraint_attachment_audio_play_button_group"
-            app:layout_constraintTop_toTopOf="@id/layout_constraint_attachment_audio_play_button_group" />
+            android:textColor="@color/text"
+            android:textSize="@dimen/audio_button_play_pause_text_size"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
 
         <ProgressBar
             android:id="@+id/progress_bar_attachment_audio_file_loading"
-            android:layout_width="@dimen/audio_button_play_pause_width"
-            android:layout_height="@dimen/audio_button_play_pause_width"
+            android:layout_width="@dimen/audio_message_progress_bar_xy"
+            android:layout_height="@dimen/audio_message_progress_bar_xy"
             android:indeterminate="true"
-            android:indeterminateTint="@color/primaryText"
+            android:indeterminateTint="@color/text"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/button_attachment_audio_icon_play_pause_button"
-            app:layout_constraintEnd_toEndOf="@id/button_attachment_audio_icon_play_pause_button"
-            app:layout_constraintStart_toStartOf="@id/button_attachment_audio_icon_play_pause_button"
-            app:layout_constraintTop_toTopOf="@id/button_attachment_audio_icon_play_pause_button"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-
-    <SeekBar
-        android:id="@+id/seek_bar_attachment_audio"
-        android:layout_width="130dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/default_layout_margin"
-        android:progressTint="@color/receivedIcon"
-        android:thumbTint="@color/receivedIcon"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/text_view_attachment_audio_remaining_duration"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/layout_constraint_attachment_audio_play_button_group"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:progress="20" />
-
-    <TextView
-        android:id="@+id/text_view_attachment_audio_remaining_duration"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:fontFamily="@font/roboto_regular"
-        android:textSize="14sp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_constraint_attachment_audio_progress"
+        android:layout_width="@dimen/audio_button_play_pause_width"
+        android:layout_height="@dimen/message_type_audio_attachment_height"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/seek_bar_attachment_audio"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="21:00" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/text_view_attachment_audio_remaining_duration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/roboto_regular"
+            android:textSize="@dimen/audio_button_duration_text_size"
+            android:textColor="@color/text"
+            android:text="00:00"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_file.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_file.xml
@@ -6,7 +6,6 @@
     android:layout_height="@dimen/message_type_file_attachment_height"
     android:visibility="gone"
     tools:layout_height="@dimen/message_type_file_attachment_height"
-    tools:layout_width="300dp"
     tools:visibility="visible">
 
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_image.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_image.xml
@@ -7,7 +7,6 @@
     android:minHeight="@dimen/message_type_image_attachment_min_height"
     android:padding="2dp"
     android:visibility="gone"
-    tools:layout_width="300dp"
     tools:visibility="visible">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_video.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_attachment_video.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:visibility="gone"
-    tools:layout_width="300dp"
     tools:visibility="visible">
 
     <VideoView

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_bot_response.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_bot_response.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="WebViewLayout"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:padding="@dimen/default_layout_margin"
     android:minHeight="20dp"

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_direct_payment.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_direct_payment.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="@dimen/message_type_direct_payment_height"
     android:paddingHorizontal="@dimen/default_layout_margin"
     android:paddingTop="@dimen/default_list_row_padding_vertical"

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_invoice.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_invoice.xml
@@ -6,7 +6,6 @@
     android:layout_height="wrap_content"
     android:visibility="gone"
     tools:background="@color/receivedMsgBG"
-    tools:layout_width="200dp"
     tools:padding="@dimen/default_layout_margin"
     tools:visibility="visible">
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_podcast_boost.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_message_type_podcast_boost.xml
@@ -2,8 +2,9 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/message_type_boost_height"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingVertical="@dimen/default_half_layout_margin"
     android:visibility="gone"
     tools:visibility="visible">
 
@@ -33,7 +34,8 @@
         android:text="-"
         app:layout_constraintStart_toEndOf="@+id/text_view_podcast_boost_label"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="3 000"/>
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/button_boost"
@@ -44,7 +46,9 @@
         android:backgroundTint="@color/primaryGreen"
         android:src="@drawable/ic_boost"
         android:layout_marginEnd="@dimen/default_layout_margin"
+        android:layout_marginStart="@dimen/default_layout_margin"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/text_view_podcast_boost_amount"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_selected_message_menu.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_selected_message_menu.xml
@@ -61,22 +61,82 @@
         android:layout_height="3.5dp"
         app:layout_constraintBottom_toBottomOf="parent" />
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/image_view_selected_message_menu_arrow_top"
-        android:layout_width="8dp"
-        android:layout_height="5dp"
-        android:background="@drawable/selected_received_message_top_arrow"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_constraint_selected_message_menu_arrow_top_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent">
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/image_view_selected_message_menu_arrow_bottom"
-        android:layout_width="8dp"
-        android:layout_height="5dp"
-        android:background="@drawable/selected_received_message_bottom_arrow"
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/image_view_selected_message_menu_arrow_top_center"
+            android:layout_width="@dimen/selected_message_menu_arrow_width"
+            android:layout_height="@dimen/selected_message_menu_arrow_height"
+            android:background="@drawable/selected_received_message_top_arrow"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/image_view_selected_message_menu_arrow_top_right"
+            android:layout_width="@dimen/selected_message_menu_arrow_width"
+            android:layout_height="@dimen/selected_message_menu_arrow_height"
+            android:layout_marginRight="@dimen/selected_message_menu_arrow_right_end_margin"
+            android:background="@drawable/selected_received_message_top_arrow"
+            android:visibility="visible"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/image_view_selected_message_menu_arrow_top_left"
+            android:layout_width="@dimen/selected_message_menu_arrow_width"
+            android:layout_height="@dimen/selected_message_menu_arrow_height"
+            android:layout_marginLeft="@dimen/selected_message_menu_arrow_left_start_margin"
+            android:background="@drawable/selected_received_message_top_arrow"
+            android:visibility="visible"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_constraint_selected_message_menu_arrow_bottom_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/image_view_selected_message_menu_arrow_bottom_center"
+            android:layout_width="@dimen/selected_message_menu_arrow_width"
+            android:layout_height="@dimen/selected_message_menu_arrow_height"
+            android:background="@drawable/selected_received_message_bottom_arrow"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/image_view_selected_message_menu_arrow_bottom_right"
+            android:layout_width="@dimen/selected_message_menu_arrow_width"
+            android:layout_height="@dimen/selected_message_menu_arrow_height"
+            android:layout_marginRight="@dimen/selected_message_menu_arrow_right_end_margin"
+            android:background="@drawable/selected_received_message_bottom_arrow"
+            android:visibility="visible"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/image_view_selected_message_menu_arrow_bottom_left"
+            android:layout_width="@dimen/selected_message_menu_arrow_width"
+            android:layout_height="@dimen/selected_message_menu_arrow_height"
+            android:layout_marginLeft="@dimen/selected_message_menu_arrow_left_start_margin"
+            android:background="@drawable/selected_received_message_bottom_arrow"
+            android:visibility="visible"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_unsupported_message_type_placeholder.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/layout/layout_unsupported_message_type_placeholder.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:padding="@dimen/default_layout_margin"
     android:visibility="gone"
@@ -11,7 +11,7 @@
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_view_placeholder_message"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fontFamily="@font/roboto_italic"
         android:paddingVertical="@dimen/group_action_message_padding_vertical"

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
@@ -72,6 +72,7 @@
 
     <dimen name="message_type_boost_min_width">150dp</dimen>
     <dimen name="message_views_fixed_min_width">200dp</dimen>
+    <dimen name="message_views_fixed_max_width">350dp</dimen>
 
     <!-- Images -->
     <dimen name="loading_image_progress_xy">50dp</dimen>

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
@@ -104,6 +104,10 @@
     <dimen name="selected_message_menu_icon_padding">8dp</dimen>
     <dimen name="selected_message_menu_item_height">40dp</dimen>
     <dimen name="selected_message_menu_item_text_size">12sp</dimen>
+    <dimen name="selected_message_menu_arrow_width">8dp</dimen>
+    <dimen name="selected_message_menu_arrow_height">5dp</dimen>
+    <dimen name="selected_message_menu_arrow_left_start_margin">48dp</dimen>
+    <dimen name="selected_message_menu_arrow_right_end_margin">20dp</dimen>
 
     <!-- Menu -->
     <dimen name="options_menu_option_height">50dp</dimen>

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
@@ -44,12 +44,6 @@
     <dimen name="group_action_message_padding_vertical">4dp</dimen>
     <dimen name="group_request_message_button_xy">27dp</dimen>
 
-
-    <!-- message_holder_in_photo_holder_xy + 8dp -->
-    <dimen name="message_holder_space_width_left">44dp</dimen>
-    <dimen name="message_holder_space_width_right">6dp</dimen>
-
-
     <!-- Message type heights  -->
     <dimen name="message_type_boost_height">50dp</dimen>
     <dimen name="message_type_direct_payment_height">46dp</dimen>
@@ -71,6 +65,9 @@
     <dimen name="message_type_call_invite_holder_height_large">212dp</dimen>
     <dimen name="message_type_call_invite_holder_height_small">160dp</dimen>
     <dimen name="message_type_call_invite_join_button_height">38dp</dimen>
+
+    <dimen name="message_type_boost_min_width">150dp</dimen>
+    <dimen name="message_views_fixed_min_width">200dp</dimen>
 
     <!-- Images -->
     <dimen name="loading_image_progress_xy">50dp</dimen>

--- a/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
+++ b/sphinx/screens/chats/chat-common/chat-common/src/main/res/values/dimens.xml
@@ -33,6 +33,10 @@
     <dimen name="background_message_holder_default_padding_top">12dp</dimen>
     <dimen name="message_holder_in_photo_holder_xy">32dp</dimen>
     <dimen name="audio_button_play_pause_width">60dp</dimen>
+    <dimen name="audio_message_progress_bar_xy">30dp</dimen>
+    <dimen name="audio_message_seek_bar_margin_horizontal">48dp</dimen>
+    <dimen name="audio_button_play_pause_text_size">25sp</dimen>
+    <dimen name="audio_button_duration_text_size">14sp</dimen>
     <dimen name="video_attachment_play_pause_button_xy">50dp</dimen>
     <dimen name="image_holder_boost_reaction_xy">26dp</dimen>
     <dimen name="icon_container_message_payment_direction_xy">26dp</dimen>


### PR DESCRIPTION
- Changes to adapt bubble width to text size (for simple text messages)
- All the views for other message types (images, bot response, direct payments, link previews, etc) has a fixed size calculated based on screen width with a max and a min
- Small space added at the bottom of chat recyclerView using a FooterListAdapter
- Fix for selected message row on grouped messages
- Fix for message menu position and arrow on small message bubbles