### PR TITLE
Add Friend button not responding

### DIFF
--- a/sphinx/screens/dashboard/dashboard/src/main/java/chat/sphinx/dashboard/ui/DashboardFragment.kt
+++ b/sphinx/screens/dashboard/dashboard/src/main/java/chat/sphinx/dashboard/ui/DashboardFragment.kt
@@ -262,6 +262,7 @@ internal class DashboardFragment : MotionLayoutFragment<
                 dashboardPodcastViewModel.pausePodcastIfPlaying()
 
                 podcastPlayerBinding.root.gone
+                binding.swipeRevealLayoutPlayer.gone
                 binding.imageViewBottomBarShadow.visible
             }
 
@@ -570,6 +571,7 @@ internal class DashboardFragment : MotionLayoutFragment<
                             root.gone
 
                             binding.apply {
+                                swipeRevealLayoutPlayer.gone
                                 imageViewPlayerBarShadow.gone
                                 imageViewBottomBarShadow.visible
                             }
@@ -604,6 +606,8 @@ internal class DashboardFragment : MotionLayoutFragment<
 
                                 imageViewPlayerBarShadow.visible
                                 imageViewBottomBarShadow.gone
+
+                                swipeRevealLayoutPlayer.visible
                             }
 
                             root.visible

--- a/sphinx/screens/dashboard/dashboard/src/main/res/layout/fragment_dashboard.xml
+++ b/sphinx/screens/dashboard/dashboard/src/main/res/layout/fragment_dashboard.xml
@@ -49,6 +49,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/player_bar_height_with_shadow"
         app:layout_constraintBottom_toTopOf="@+id/layout_dashboard_nav_bar"
+        android:visibility="gone"
         app:mode="same_level"
         app:dragEdge="right">
 


### PR DESCRIPTION
Fix for add friend button not touchable because of the podcast player swipeToReveal intercepting it