### PR TITLE
catch common crash caused by response UNCHECKED_CAST

### DIFF
--- a/sphinx/application/network/features/feature-socket-io/src/main/java/chat/sphinx/feature_socket_io/SocketIOManagerImpl.kt
+++ b/sphinx/application/network/features/feature-socket-io/src/main/java/chat/sphinx/feature_socket_io/SocketIOManagerImpl.kt
@@ -228,9 +228,13 @@ class SocketIOManagerImpl(
                 @Exhaustive
                 when (response) {
                     is Response.Error -> {
-                        response.exception?.let {
-                            LOG.e(TAG, response.message, it)
-                        } ?: LOG.w(TAG, response.message)
+                        try {
+                            response.exception?.let {
+                                LOG.e(TAG, response.message, it)
+                            } ?: LOG.w(TAG, response.message)
+                        } catch (e: Exception) {
+                            e.message?.let { LOG.e(TAG, it, e) }
+                        }
                         return response
                     }
                     is Response.Success -> {


### PR DESCRIPTION
add catch for response UNCHECKED_CAST exception: `java.lang.ClassCastException: java.lang.String cannot be cast to chat.sphinx.wrapper_relay.TransportToken chat.sphinx.feature_socket_io.SocketIOManagerImpl.buildSocket(SocketIOManagerImpl.kt:650)`