### PR TITLE
Animate podcast player dismiss transition

### DIFF
--- a/sphinx/activity/main/activitymain/src/main/java/chat/sphinx/activitymain/MainActivity.kt
+++ b/sphinx/activity/main/activitymain/src/main/java/chat/sphinx/activitymain/MainActivity.kt
@@ -67,6 +67,10 @@ class MainActivity: MotionLayoutNavigationActivity<
     override val navigationViewModel: MainViewModel
         get() = viewModel
 
+    private var currentDetailScreenIsPodcastPlayer = false
+    private var podcastPlayerDismissalPending = false
+    private var finishingPodcastPlayerDismissal = false
+
     companion object {
         private var statusBarInsets: InsetPadding? = null
         private var navigationBarInsets: InsetPadding? = null
@@ -151,14 +155,42 @@ class MainActivity: MotionLayoutNavigationActivity<
                 .navigationRequestSharedFlow
                 .collect { request ->
                     if (
+                        request.first is PopBackStack &&
+                        currentDetailScreenIsPodcastPlayer &&
+                        !podcastPlayerDismissalPending &&
+                        !finishingPodcastPlayerDismissal
+                    ) {
+                        podcastPlayerDismissalPending = true
+                        viewModel.updateViewState(MainViewState.PodcastPlayerDetailScreenInactive)
+                        return@collect
+                    }
+
+                    val wasPodcastPlayerDetail = currentDetailScreenIsPodcastPlayer
+
+                    if (
                         viewModel
                             .detailDriver
                             .executeNavigationRequest(detailNavController, request)
                     ) {
                         if (detailNavController.previousBackStackEntry == null) {
-                            viewModel.updateViewState(MainViewState.DetailScreenInactive)
+                            currentDetailScreenIsPodcastPlayer = false
+                            viewModel.updateViewState(
+                                if (finishingPodcastPlayerDismissal || wasPodcastPlayerDetail) {
+                                    finishingPodcastPlayerDismissal = false
+                                    MainViewState.PodcastPlayerDetailScreenHidden
+                                } else {
+                                    MainViewState.DetailScreenInactive
+                                }
+                            )
                         } else {
-                            viewModel.updateViewState(MainViewState.DetailScreenActive)
+                            currentDetailScreenIsPodcastPlayer = isPodcastPlayerDetailScreen()
+                            viewModel.updateViewState(
+                                if (currentDetailScreenIsPodcastPlayer) {
+                                    MainViewState.PodcastPlayerDetailScreenActive
+                                } else {
+                                    MainViewState.DetailScreenActive
+                                }
+                            )
                         }
                     }
                 }
@@ -237,6 +269,15 @@ class MainActivity: MotionLayoutNavigationActivity<
             is MainViewState.DetailScreenInactive -> {
                 binding.layoutMotionMain.setTransitionDuration(250)
             }
+            is MainViewState.PodcastPlayerDetailScreenActive -> {
+                binding.layoutMotionMain.setTransitionDuration(400)
+            }
+            is MainViewState.PodcastPlayerDetailScreenInactive -> {
+                binding.layoutMotionMain.setTransitionDuration(325)
+            }
+            is MainViewState.PodcastPlayerDetailScreenHidden -> {
+                binding.layoutMotionMain.setTransitionDuration(90)
+            }
         }
         viewState.transitionToEndSet(binding.layoutMotionMain)
     }
@@ -257,15 +298,34 @@ class MainActivity: MotionLayoutNavigationActivity<
     // To Handle swipe behaviour
     override fun onTransitionCompleted(motionLayout: MotionLayout?, currentId: Int) {
         transitionInProgress = false
-        if (
-            currentId == MainViewState.DetailScreenInactive.endSetId &&
-            detailNavController.previousBackStackEntry != null
-        ) {
-            lifecycleScope.launch {
-                viewModel.detailDriver.submitNavigationRequest(
-                    PopBackStack(R.id.navigation_detail_blank_fragment)
-                )
+
+        when {
+            currentId == MainViewState.PodcastPlayerDetailScreenInactive.endSetId &&
+                    currentDetailScreenIsPodcastPlayer -> {
+                finishPodcastPlayerDismissal()
             }
+            currentId == MainViewState.DetailScreenInactive.endSetId &&
+                    detailNavController.previousBackStackEntry != null -> {
+                lifecycleScope.launch {
+                    viewModel.detailDriver.submitNavigationRequest(
+                        PopBackStack(R.id.navigation_detail_blank_fragment)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun isPodcastPlayerDetailScreen(): Boolean =
+        detailNavController.currentDestination?.id == R.id.navigation_podcast_player_fragment
+
+    private fun finishPodcastPlayerDismissal() {
+        podcastPlayerDismissalPending = false
+        finishingPodcastPlayerDismissal = true
+
+        lifecycleScope.launch {
+            viewModel.detailDriver.submitNavigationRequest(
+                PopBackStack(R.id.navigation_detail_blank_fragment)
+            )
         }
     }
 
@@ -337,4 +397,3 @@ class MainActivity: MotionLayoutNavigationActivity<
         }
     }
 }
-

--- a/sphinx/activity/main/activitymain/src/main/java/chat/sphinx/activitymain/ui/MainViewState.kt
+++ b/sphinx/activity/main/activitymain/src/main/java/chat/sphinx/activitymain/ui/MainViewState.kt
@@ -27,4 +27,52 @@ sealed class MainViewState: MotionLayoutViewState<MainViewState>() {
 
         override fun restoreMotionScene(motionLayout: MotionLayout) {}
     }
+
+    object PodcastPlayerDetailScreenActive: MainViewState() {
+        override val startSetId: Int
+            get() = R.id.motion_scene_main_podcast_player_minimized
+        override val endSetId: Int
+            get() = R.id.motion_scene_main_set2
+
+        override fun transitionToEndSet(motionLayout: MotionLayout) {
+            motionLayout.setTransition(R.id.transition_main_podcast_player_minimized_to_set2)
+            motionLayout.setProgress(0F, 0F)
+            motionLayout.transitionToEnd()
+        }
+
+        override fun restoreMotionScene(motionLayout: MotionLayout) {
+            motionLayout.setTransition(R.id.transition_main_podcast_player_minimized_to_set2)
+            motionLayout.setProgress(1F, 1F)
+        }
+    }
+
+    object PodcastPlayerDetailScreenInactive: MainViewState() {
+        override val startSetId: Int
+            get() = R.id.motion_scene_main_set2
+        override val endSetId: Int
+            get() = R.id.motion_scene_main_podcast_player_minimized
+
+        override fun transitionToEndSet(motionLayout: MotionLayout) {
+            motionLayout.setTransition(R.id.transition_main_set2_to_podcast_player_minimized)
+            motionLayout.setProgress(0F, 0F)
+            motionLayout.transitionToEnd()
+        }
+
+        override fun restoreMotionScene(motionLayout: MotionLayout) {}
+    }
+
+    object PodcastPlayerDetailScreenHidden: MainViewState() {
+        override val startSetId: Int
+            get() = R.id.motion_scene_main_podcast_player_minimized
+        override val endSetId: Int
+            get() = R.id.motion_scene_main_set1
+
+        override fun transitionToEndSet(motionLayout: MotionLayout) {
+            motionLayout.setTransition(R.id.transition_main_podcast_player_minimized_to_set1)
+            motionLayout.setProgress(0F, 0F)
+            motionLayout.transitionToEnd()
+        }
+
+        override fun restoreMotionScene(motionLayout: MotionLayout) {}
+    }
 }

--- a/sphinx/activity/main/activitymain/src/main/res/xml/motion_scene_main.xml
+++ b/sphinx/activity/main/activitymain/src/main/res/xml/motion_scene_main.xml
@@ -165,6 +165,39 @@
     </ConstraintSet>
 
 
+    <!--
+           Set 3: Podcast Player minimized to the dashboard player bar
+    -->
+    <ConstraintSet
+        android:id="@+id/motion_scene_main_podcast_player_minimized"
+        app:deriveConstraintsFrom="@+id/motion_scene_main_set1">
+
+        <Constraint android:id="@+id/nav_host_fragment_detail">
+            <Layout
+                android:layout_width="0dp"
+                android:layout_height="@dimen/player_bar_height"
+                android:layout_marginBottom="@dimen/default_bottom_bar_height"
+                app:layout_constraintBottom_toTopOf="@+id/layout_constraint_main_navigation_bar"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+            <PropertySet
+                android:alpha="0" />
+        </Constraint>
+
+        <Constraint android:id="@+id/space_detail_swipe_target">
+            <Layout
+                android:layout_width="0dp"
+                android:layout_height="20dp"
+                android:layout_marginStart="@dimen/detail_header_nav_button_width"
+                android:layout_marginEnd="@dimen/detail_header_exit_button_width"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/nav_host_fragment_detail" />
+        </Constraint>
+
+    </ConstraintSet>
+
+
     <!-- ////////////////////////////////////////////////////////////////////////////////-->
     <!-- ////////////////////////////////////////////////////////////////////////////////-->
     <!-- ////////////////////////////// Transitions /////////////////////////////////////-->
@@ -191,5 +224,34 @@
             app:touchRegionId="@id/space_detail_swipe_target" />
 
     </Transition>
+
+    <Transition
+        android:id="@+id/transition_main_podcast_player_minimized_to_set2"
+        app:constraintSetEnd="@+id/motion_scene_main_set2"
+        app:constraintSetStart="@+id/motion_scene_main_podcast_player_minimized"
+        app:duration="400"
+        app:motionInterpolator="cubic(0.41,0.39,0,1)">
+
+        <OnSwipe
+            app:dragDirection="dragUp"
+            app:touchAnchorId="@id/space_detail_swipe_target"
+            app:touchAnchorSide="bottom"
+            app:touchRegionId="@id/space_detail_swipe_target" />
+
+    </Transition>
+
+    <Transition
+        android:id="@+id/transition_main_set2_to_podcast_player_minimized"
+        app:constraintSetEnd="@+id/motion_scene_main_podcast_player_minimized"
+        app:constraintSetStart="@+id/motion_scene_main_set2"
+        app:duration="325"
+        app:motionInterpolator="cubic(0.4,0,0.2,1)" />
+
+    <Transition
+        android:id="@+id/transition_main_podcast_player_minimized_to_set1"
+        app:constraintSetEnd="@+id/motion_scene_main_set1"
+        app:constraintSetStart="@+id/motion_scene_main_podcast_player_minimized"
+        app:duration="90"
+        app:motionInterpolator="linear" />
 
 </MotionScene>


### PR DESCRIPTION
## Summary
- Add a podcast-specific minimized MotionLayout constraint set aligned to the dashboard mini-player area.
- Route podcast player presentation and dismissal through explicit mini-player transitions.
- Defer the detail back stack pop until the shrink animation completes, then hide the blank detail host.
- Leave generic detail-screen transitions unchanged.

Closes #422

Bounty: Sphinx #174 / #16

## Verification
- `xmllint --noout sphinx/activity/main/activitymain/src/main/res/xml/motion_scene_main.xml sphinx/activity/main/activitymain/src/main/res/layout/activity_main.xml`
- `./gradlew :sphinx:activity:main:activitymain:assembleDebug`