### PR TITLE
Integrate dashboard Robolectric UI smoke test

### DIFF
--- a/sphinx/screens/dashboard/dashboard/build.gradle
+++ b/sphinx/screens/dashboard/dashboard/build.gradle
@@ -26,6 +26,11 @@ android {
             minifyEnabled false
         }
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
     namespace 'chat.sphinx.dashboard'
 }
 
@@ -82,6 +87,8 @@ dependencies {
     kapt kaptDeps.google.hilt
 
     testImplementation testDeps.junit
+    testImplementation testDeps.androidx.core
+    testImplementation testDeps.robolectric
 
     androidTestImplementation testDeps.androidx.core
     androidTestImplementation testDeps.androidx.espresso

--- a/sphinx/screens/dashboard/dashboard/src/test/java/chat/sphinx/dashboard/DashboardLayoutRobolectricTest.kt
+++ b/sphinx/screens/dashboard/dashboard/src/test/java/chat/sphinx/dashboard/DashboardLayoutRobolectricTest.kt
@@ -1,0 +1,39 @@
+package chat.sphinx.dashboard
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class DashboardLayoutRobolectricTest {
+
+    @Test
+    fun `dashboard layout exposes primary navigation affordances`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.setTheme(R.style.AppTheme)
+
+        val dashboard = LayoutInflater.from(context)
+            .inflate(R.layout.fragment_dashboard, null, false)
+
+        assertNotNull(dashboard.findViewById(R.id.layout_dashboard_header))
+        assertNotNull(dashboard.findViewById(R.id.tab_layout_dashboard_tabs))
+        assertNotNull(dashboard.findViewById(R.id.view_pager_dashboard_tabs))
+        assertNotNull(dashboard.findViewById(R.id.layout_dashboard_nav_bar))
+
+        assertNotNull(dashboard.findViewById(R.id.nav_bar_button_payment_receive))
+        assertNotNull(dashboard.findViewById(R.id.nav_bar_button_transactions))
+        assertNotNull(dashboard.findViewById(R.id.nav_bar_button_scanner))
+        assertNotNull(dashboard.findViewById(R.id.nav_bar_button_payment_send))
+
+        val player = dashboard.findViewById<View>(R.id.swipe_reveal_layout_player)
+        assertEquals(View.GONE, player.visibility)
+    }
+}


### PR DESCRIPTION
## Summary
- enable Android resource loading for dashboard JVM UI tests
- add Robolectric and AndroidX test-core dependencies to the dashboard module
- add a dashboard layout smoke test that inflates the view and verifies the tab bar, pager, bottom navigation actions, and hidden player affordance

Closes #736

## Verification
- `git diff --check` passed locally
- `./gradlew :sphinx:screens:dashboard:dashboard:testDebugUnitTest --dry-run` could not run locally because this machine has no Java runtime installed